### PR TITLE
Show an edit link in the district contact block

### DIFF
--- a/modules/custom/ccsf_participatory_budget/ccsf_participatory_budget.module
+++ b/modules/custom/ccsf_participatory_budget/ccsf_participatory_budget.module
@@ -8,7 +8,8 @@ function ccsf_participatory_budget_theme($existing, $type, $theme, $path) {
   return array(
     'ccsf_participatory_budget__district_contact' => array(
       'variables' => array(
-        'district' => null
+        'district' => null,
+        'can_update' => null,
       ),
     ),
     'ccsf_participatory_budget_help' => array(

--- a/modules/custom/ccsf_participatory_budget/src/Plugin/Block/DistrictContactBlock.php
+++ b/modules/custom/ccsf_participatory_budget/src/Plugin/Block/DistrictContactBlock.php
@@ -30,6 +30,7 @@ class DistrictContactBlock extends BlockBase {
     return array(
       '#theme' => 'ccsf_participatory_budget__district_contact',
       '#district' => $node->get('field_district')->entity,
+      '#can_update' => $node->get('field_district')->entity->access('update'),
     );
   }
 

--- a/themes/custom/participatory_budget/templates/block/ccsf-participatory-budget--district-contact.html.twig
+++ b/themes/custom/participatory_budget/templates/block/ccsf-participatory-budget--district-contact.html.twig
@@ -9,6 +9,6 @@
   </ul>
 
   {% if can_update %}
-    <a href="{{ path('entity.district.canonical', { 'district': district.id() }) }}">Edit</a>
+    <a href="{{ path('entity.district.canonical', { 'district': district.id.value }) }}">Edit</a>
   {% endif %}
 </div>

--- a/themes/custom/participatory_budget/templates/block/ccsf-participatory-budget--district-contact.html.twig
+++ b/themes/custom/participatory_budget/templates/block/ccsf-participatory-budget--district-contact.html.twig
@@ -7,4 +7,8 @@
     <li>{{ district.field_contact_phone.value }}</li>
     <li><a href="{{ district.field_external_district_page.uri }}">For more District {{ district.field_district_number.value }} information.</a></li>
   </ul>
+
+  {% if can_update %}
+    <a href="{{ path('entity.district.canonical', { 'district': district.id() }) }}">Edit</a>
+  {% endif %}
 </div>


### PR DESCRIPTION
If the user has access to update the entity.

Curious if this is the most Drupal way to do this.

I attempted to just do `{% if district.access('update') %}` in the template, but this threw a Twig_Sandbox_SecurityError (`calling 'access' method on a 'Drupal\ccsf_district\Entity\District' object is not allowed`).