### PR TITLE
[WIP] Configure CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,144 @@
+# https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
+defaults: &defaults
+  docker:
+    - image: quay.io/pantheon-public/build-tools-ci:1.x
+  working_directory: ~/example_drops_8_composer
+  environment:
+    #=========================================================================
+    # In addition to the environment variables defined in this file, also
+    # add the following variables in the Circle CI UI.
+    #
+    # See: https://circleci.com/docs/2.0/env-vars/
+    #
+    # TERMINUS_SITE:  Name of the Pantheon site to run tests on, e.g. my_site
+    # TERMINUS_TOKEN: The Pantheon machine token
+    # GITHUB_TOKEN:   The GitHub personal access token
+    # GIT_EMAIL:      The email address to use when making commits
+    #
+    # TEST_SITE_NAME: The name of the test site to provide when installing.
+    # ADMIN_PASSWORD: The admin password to use when installing.
+    # ADMIN_EMAIL:    The email address to give the admin when installing.
+    #=========================================================================
+    TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+
+    # The variables below usually do not need to be modified.
+
+    #======================================================================================================================================
+    # Circle CI 2.0 does not yet expand environment variables so they have to be manually EXPORTed
+    # Once environment variables can be expanded the variables below can be uncommented and the EXPORTs in set-up-globals.sh can be removed
+    # See: https://discuss.circleci.com/t/unclear-how-to-work-with-user-variables-circleci-provided-env-variables/12810/11
+    # See: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
+    # See: https://discuss.circleci.com/t/circle-2-0-global-environment-variables/8681
+    #======================================================================================================================================
+
+    NOTIFY: 'scripts/github/add-commit-comment {project} {sha} "Created multidev environment [{site}#{env}]({dashboard-url})." {site-url}'
+    ADMIN_USERNAME: admin
+    # BUILD_TOOLS_VERSION: ^2.0.0-alpha4
+    TERM: dumb
+
+version: 2
+jobs:
+    # @todo: common initialization: 'composer install' for the site-under-test
+    build:
+        <<: *defaults
+        steps:
+            - checkout
+
+            - restore_cache:
+                keys:
+                    - composer-cache
+                    - terminus-install
+
+            - run:
+                # Set TERMINUS_ENV and related environment variables.
+                # https://github.com/pantheon-systems/docker-build-tools-ci/blob/1.x/scripts/set-environment
+                name: environment
+                command: /build-tools-ci/scripts/set-environment
+
+            - run:
+                name: run composer install to get the vendor directory
+                command: composer install
+
+            - save_cache:
+                key: composer-cache
+                paths:
+                    - $HOME/.composer/cache
+
+            - save_cache:
+                key: terminus-install
+                paths:
+                    - $(TERMINUS_PLUGINS_DIR:-~/.terminus/plugins)
+
+            - run:
+                name: lint php code for syntax errors
+                command: composer -n lint
+
+            - run:
+                name: check coding standards
+                command: composer -n code-sniff
+
+            - run:
+                name: run unit tests
+                command: composer -n unit-test
+
+    build_deploy_and_test:
+        <<: *defaults
+        steps:
+            - checkout
+
+            - restore_cache:
+                keys:
+                    - composer-cache
+                    - terminus-install
+
+            - run:
+                # Set TERMINUS_ENV and related environment variables.
+                # https://github.com/pantheon-systems/docker-build-tools-ci/blob/1.x/scripts/set-environment
+                name: dependencies
+                command: /build-tools-ci/scripts/set-environment
+
+            - run:
+                name: install dev dependencies, build assets, etc.
+                command: ./.circleci/scripts/pantheon/01-prepare
+
+            - run:
+                name: build assets
+                command: composer -n build-assets
+
+            - run:
+                name: prepare database for site-under test
+                command: ./.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
+                # command: ./.circleci/scripts/pantheon/02-init-site-under-test-reinstall-new
+
+            - run:
+                name: run composer install again to get dev dependencies
+                command: composer install
+
+            - run:
+                name: run functional tests with Behat
+                command: ./tests/scripts/run-behat
+
+            - run:
+                name: post-test actions
+                command: ./.circleci/scripts/pantheon/03-post-test
+
+            - run:
+                name: handle merge to master (if needed)
+                command: ./.circleci/scripts/pantheon/04-merge-master
+
+            - run:
+                name: remove transient test fixtures
+                command: ./.circleci/scripts/pantheon/09-cleanup-fixtures
+
+    # TODO:
+    # 04-merge-master
+    # 09-cleanup-fixtures
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      # Install dev dependencies and do simple tests (sniff, unit tests, etc.)
+      - build
+      # Build deploy and test on target platform
+      - build_deploy_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 defaults: &defaults
   docker:
     - image: quay.io/pantheon-public/build-tools-ci:1.x
-  working_directory: ~/example_drops_8_composer
+  working_directory: ~/participatory_budget
   environment:
     #=========================================================================
     # In addition to the environment variables defined in this file, also

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
 
             - run:
                 name: run functional tests with Behat
-                command: ./tests/scripts/run-behat
+                command: ./tests/scripts/run-pantheon-behat
 
             - run:
                 name: post-test actions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,6 @@
+# Largely borrowed from https://github.com/pantheon-systems/example-drops-8-composer
+# Updates to the example repository should likely be considered for inclusion here
+#
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 defaults: &defaults
   docker:
@@ -12,12 +15,7 @@ defaults: &defaults
     #
     # TERMINUS_SITE:  Name of the Pantheon site to run tests on, e.g. my_site
     # TERMINUS_TOKEN: The Pantheon machine token
-    # GITHUB_TOKEN:   The GitHub personal access token
     # GIT_EMAIL:      The email address to use when making commits
-    #
-    # TEST_SITE_NAME: The name of the test site to provide when installing.
-    # ADMIN_PASSWORD: The admin password to use when installing.
-    # ADMIN_EMAIL:    The email address to give the admin when installing.
     #=========================================================================
     TZ: "/usr/share/zoneinfo/America/Los_Angeles"
 
@@ -108,7 +106,6 @@ jobs:
             - run:
                 name: prepare database for site-under test
                 command: ./.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
-                # command: ./.circleci/scripts/pantheon/02-init-site-under-test-reinstall-new
 
             - run:
                 name: run composer install again to get dev dependencies
@@ -129,10 +126,6 @@ jobs:
             - run:
                 name: remove transient test fixtures
                 command: ./.circleci/scripts/pantheon/09-cleanup-fixtures
-
-    # TODO:
-    # 04-merge-master
-    # 09-cleanup-fixtures
 
 workflows:
   version: 2

--- a/.circleci/scripts/pantheon/01-prepare
+++ b/.circleci/scripts/pantheon/01-prepare
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eo pipefail
+
+#
+# This script starts up the test process.
+#
+# - Environment settings (e.g. git config) are initialized
+# - Terminus plugins are installed
+# - Any needed code updates are done
+#
+echo "Begin build for $DEFAULT_ENV. Pantheon test environment is $TERMINUS_SITE.$TERMINUS_ENV"
+
+# Log in via Terminus
+terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
+
+# Delete leftover CI environments
+terminus -n build:env:delete:ci "$TERMINUS_SITE" --keep=2 --yes

--- a/.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
+++ b/.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eo pipefail
+
+#
+# This script prepares the site-under-test by cloning the database from
+# an existing site.
+#
+# Use EITHER this script OR the re-install-new script; do not run both.
+#
+
+# Create a new multidev site to test on
+terminus -n env:wake "$TERMINUS_SITE.dev"
+terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --clone-content --notify="$NOTIFY"
+
+# Run updatedb to ensure that the cloned database is updated for the new code.
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
+
+# If any modules, or theme files have been moved around or reorganized, in order to avoid
+# "The website encountered an unexpected error. Please try again later." error on First Visit
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" cr
+
+# If exported configuration is available, then import it.
+if [ -f "config/system.site.yml" ] ; then
+  terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- config-import --yes
+fi

--- a/.circleci/scripts/pantheon/02-init-site-under-test-reinstall-new
+++ b/.circleci/scripts/pantheon/02-init-site-under-test-reinstall-new
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+#
+# This script prepares the site-under-test by re-installing a new site.
+#
+# Use EITHER this script OR the clone-existing script; do not run both.
+#
+
+# Create a new multidev site to test on
+terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --notify="$NOTIFY"
+
+# Re-run the site installation process
+terminus -n build:env:install "$TERMINUS_SITE.$TERMINUS_ENV" --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD"

--- a/.circleci/scripts/pantheon/03-post-test
+++ b/.circleci/scripts/pantheon/03-post-test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eo pipefail
+
+#
+# This script runs any post-test operations that may be needed.
+#
+
+terminus -n secrets:set "$TERMINUS_SITE.$TERMINUS_ENV" token "$GITHUB_TOKEN" --file='github-secrets.json' --clear --skip-if-empty

--- a/.circleci/scripts/pantheon/04-merge-master
+++ b/.circleci/scripts/pantheon/04-merge-master
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eo pipefail
+
+#
+# This script handles all operations that must be done when a
+# pull request is merged back into the master branch.
+#
+if [[ $CIRCLE_BRANCH != "master" ]] ; then
+  exit 0
+fi
+
+# Merge the multidev for the PR into the dev environment
+terminus -n build:env:merge "$TERMINUS_SITE.$TERMINUS_ENV" --yes
+
+# Run updatedb on the dev environment
+terminus -n drush $TERMINUS_SITE.dev -- updatedb --yes
+
+# If there are any exported configuration files, then import them
+if [ -f "config/system.site.yml" ] ; then
+  terminus -n drush "$TERMINUS_SITE.dev" -- config-import --yes
+fi
+
+# Delete old multidev environments associated with a PR that has been
+# merged or closed.
+terminus -n build:env:delete:pr "$TERMINUS_SITE" --yes

--- a/.circleci/scripts/pantheon/09-cleanup-fixtures
+++ b/.circleci/scripts/pantheon/09-cleanup-fixtures
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eo pipefail
+
+#
+# This script deletes any fixtures that are no longer needed.
+#
+# Note that we allow the "ci-BUILD_NUMBER" and "pr-PULL_REQUEST_NUMBER"
+# multidev sites to persist until the next time the 'prepare' or
+# 'merge-master' scripts (respectively) are called.
+#
+

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,10 @@
     "autoload": {
         "psr-4": {
             "Drupal\\Core\\Composer\\": "core/lib/Drupal/Core/Composer"
-        }
+        },
+        "classmap": [
+            "scripts/composer/ScriptHandler.php"
+        ]
     },
     "scripts": {
         "build-assets": [

--- a/composer.json
+++ b/composer.json
@@ -72,14 +72,28 @@
         }
     },
     "scripts": {
-        "pre-autoload-dump": "Drupal\\Core\\Composer\\Composer::preAutoloadDump",
-        "post-autoload-dump": "Drupal\\Core\\Composer\\Composer::ensureHtaccess",
-        "post-package-install": "Drupal\\Core\\Composer\\Composer::vendorTestCodeCleanup",
-        "post-package-update": "Drupal\\Core\\Composer\\Composer::vendorTestCodeCleanup",
-        "drupal-phpunit-upgrade-check": "Drupal\\Core\\Composer\\Composer::upgradePHPUnit",
-        "drupal-phpunit-upgrade": "@composer update phpunit/phpunit --with-dependencies --no-progress",
-        "phpcs": "phpcs --standard=core/phpcs.xml.dist --runtime-set installed_paths $($COMPOSER_BINARY config vendor-dir)/drupal/coder/coder_sniffer --",
-        "phpcbf": "phpcbf --standard=core/phpcs.xml.dist --runtime-set installed_paths $($COMPOSER_BINARY config vendor-dir)/drupal/coder/coder_sniffer --"
+        "build-assets": [
+            "@prepare-for-pantheon",
+            "composer install --optimize-autoloader --no-dev"
+        ],
+        "lint": "find web/modules/custom web/themes/custom -name '*.php' -exec php -l {} \\;",
+        "code-sniff": "echo 'No code sniff step defined.'",
+        "unit-test": "echo 'No unit test step defined.'",
+        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "prepare-for-pantheon": "DrupalProject\\composer\\ScriptHandler::prepareForPantheon",
+        "post-install-cmd": [
+            "@drupal-scaffold",
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+        ],
+        "post-update-cmd": [
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "find .circleci/scripts/pantheon/ -type f | xargs chmod 755",
+            "find tests/scripts/ -type f | xargs chmod 755"
+        ],
+        "post-create-project-cmd": [
+            "@drupal-scaffold",
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+        ]
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "@prepare-for-pantheon",
             "composer install --optimize-autoloader --no-dev"
         ],
-        "lint": "find web/modules/custom web/themes/custom -name '*.php' -exec php -l {} \\;",
+        "lint": "find modules/custom themes/custom -name '*.php' -exec php -l {} \\;",
         "code-sniff": "echo 'No code sniff step defined.'",
         "unit-test": "echo 'No unit test step defined.'",
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -103,5 +103,10 @@
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
-    ]
+    ],
+    "require-dev": {
+        "behat/behat": "^3.4",
+        "drupal/drupal-extension": "^3.4",
+        "behat/mink": "^1.7"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "55158c042987bfd67d1b5f5662f5fd30",
+    "content-hash": "f28ee9623697677d5c2ef765cef3170f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5772,6 +5772,148 @@
     ],
     "packages-dev": [
         {
+            "name": "behat/behat",
+            "version": "v3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Behat.git",
+                "reference": "d60b161bff1b95ec4bb80bb8cb210ccf890314c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/d60b161bff1b95ec4bb80bb8cb210ccf890314c2",
+                "reference": "d60b161bff1b95ec4bb80bb8cb210ccf890314c2",
+                "shasum": ""
+            },
+            "require": {
+                "behat/gherkin": "^4.5.1",
+                "behat/transliterator": "^1.2",
+                "container-interop/container-interop": "^1.2",
+                "ext-mbstring": "*",
+                "php": ">=5.3.3",
+                "psr/container": "^1.0",
+                "symfony/class-loader": "~2.1||~3.0||~4.0",
+                "symfony/config": "~2.3||~3.0||~4.0",
+                "symfony/console": "~2.5||~3.0||~4.0",
+                "symfony/dependency-injection": "~2.1||~3.0||~4.0",
+                "symfony/event-dispatcher": "~2.1||~3.0||~4.0",
+                "symfony/translation": "~2.3||~3.0||~4.0",
+                "symfony/yaml": "~2.1||~3.0||~4.0"
+            },
+            "require-dev": {
+                "herrera-io/box": "~1.6.1",
+                "phpunit/phpunit": "^4.8.36|^6.3",
+                "symfony/process": "~2.5|~3.0|~4.0"
+            },
+            "suggest": {
+                "behat/mink-extension": "for integration with Mink testing framework",
+                "behat/symfony2-extension": "for integration with Symfony2 web framework",
+                "behat/yii-extension": "for integration with Yii web framework"
+            },
+            "bin": [
+                "bin/behat"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Behat": "src/",
+                    "Behat\\Testwork": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Scenario-oriented BDD framework for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "Agile",
+                "BDD",
+                "ScenarioBDD",
+                "Scrum",
+                "StoryBDD",
+                "User story",
+                "business",
+                "development",
+                "documentation",
+                "examples",
+                "symfony",
+                "testing"
+            ],
+            "time": "2017-11-27T10:37:56+00:00"
+        },
+        {
+            "name": "behat/gherkin",
+            "version": "v4.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Gherkin.git",
+                "reference": "74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a",
+                "reference": "74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5|~5",
+                "symfony/phpunit-bridge": "~2.7|~3",
+                "symfony/yaml": "~2.3|~3"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to parse features, represented in YAML files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Gherkin": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Gherkin DSL parser for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "Cucumber",
+                "DSL",
+                "gherkin",
+                "parser"
+            ],
+            "time": "2017-08-30T11:04:43+00:00"
+        },
+        {
             "name": "behat/mink",
             "version": "dev-master",
             "source": {
@@ -5884,6 +6026,65 @@
                 "testing"
             ],
             "time": "2016-03-05T08:59:47+00:00"
+        },
+        {
+            "name": "behat/mink-extension",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/MinkExtension.git",
+                "reference": "80f7849ba53867181b7e412df9210e12fba50177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/MinkExtension/zipball/80f7849ba53867181b7e412df9210e12fba50177",
+                "reference": "80f7849ba53867181b7e412df9210e12fba50177",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.0.5",
+                "behat/mink": "^1.5",
+                "php": ">=5.3.2",
+                "symfony/config": "^2.7|^3.0|^4.0"
+            },
+            "require-dev": {
+                "behat/mink-goutte-driver": "^1.1",
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "behat-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\MinkExtension": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                },
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com"
+                }
+            ],
+            "description": "Mink extension for Behat",
+            "homepage": "http://extensions.behat.org/mink",
+            "keywords": [
+                "browser",
+                "gui",
+                "test",
+                "web"
+            ],
+            "time": "2018-02-06T15:36:30+00:00"
         },
         {
             "name": "behat/mink-goutte-driver",
@@ -6002,6 +6203,81 @@
             "time": "2018-01-07T19:17:08+00:00"
         },
         {
+            "name": "behat/transliterator",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Transliterator.git",
+                "reference": "826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c",
+                "reference": "826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "chuyskywalker/rolling-curl": "^3.1",
+                "php-yaoi/php-yaoi": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Transliterator": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Artistic-1.0"
+            ],
+            "description": "String transliterator",
+            "keywords": [
+                "i18n",
+                "slug",
+                "transliterator"
+            ],
+            "time": "2017-04-04T11:38:05+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.1.0",
             "source": {
@@ -6091,6 +6367,135 @@
                 "standards"
             ],
             "time": "2017-03-18T10:28:49+00:00"
+        },
+        {
+            "name": "drupal/drupal-driver",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jhedstrom/DrupalDriver.git",
+                "reference": "919c6a39ef6a17bdcaf81dcff97b117ecfb6061c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/919c6a39ef6a17bdcaf81dcff97b117ecfb6061c",
+                "reference": "919c6a39ef6a17bdcaf81dcff97b117ecfb6061c",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/core-utility": "^8.4",
+                "php": ">=5.5.9",
+                "symfony/dependency-injection": "~2.6|~3.0",
+                "symfony/process": "~2.5|~3.0"
+            },
+            "require-dev": {
+                "drupal/coder": "~8.2.0",
+                "drush-ops/behat-drush-endpoint": "*",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "mockery/mockery": "0.9.4",
+                "phpspec/phpspec": "~2.0",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Drupal\\Driver": "src/",
+                    "Drupal\\Tests\\Driver": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Hedstrom",
+                    "email": "jhedstrom@gmail.com"
+                }
+            ],
+            "description": "A collection of reusable Drupal drivers",
+            "homepage": "http://github.com/jhedstrom/DrupalDriver",
+            "keywords": [
+                "drupal",
+                "test",
+                "web"
+            ],
+            "time": "2018-02-09T18:02:28+00:00"
+        },
+        {
+            "name": "drupal/drupal-extension",
+            "version": "v3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jhedstrom/drupalextension.git",
+                "reference": "50ff0f413f0dc4732f49638e743f86f45e835e50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jhedstrom/drupalextension/zipball/50ff0f413f0dc4732f49638e743f86f45e835e50",
+                "reference": "50ff0f413f0dc4732f49638e743f86f45e835e50",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "~3.2",
+                "behat/mink": "~1.5",
+                "behat/mink-extension": "~2.0",
+                "behat/mink-goutte-driver": "~1.0",
+                "behat/mink-selenium2-driver": "~1.1",
+                "drupal/drupal-driver": "~1.3",
+                "symfony/dependency-injection": "~2.7|~3.0",
+                "symfony/event-dispatcher": "~2.7|~3.0"
+            },
+            "require-dev": {
+                "behat/mink-zombie-driver": "^1.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phpspec/phpspec": "~2.0",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "behat-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Drupal\\Drupal": "src/",
+                    "Drupal\\Exception": "src/",
+                    "Drupal\\DrupalExtension": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Hedstrom",
+                    "email": "jhedstrom@gmail.com"
+                },
+                {
+                    "name": "Melissa Anderson",
+                    "homepage": "https://github.com/eliza411"
+                },
+                {
+                    "name": "Pieter Frenssen",
+                    "homepage": "https://github.com/pfrenssen"
+                }
+            ],
+            "description": "Drupal extension for Behat",
+            "homepage": "http://drupal.org/project/drupalextension",
+            "keywords": [
+                "drupal",
+                "test",
+                "web"
+            ],
+            "time": "2017-12-06T20:35:40+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @file
+ * Contains \DrupalProject\composer\ScriptHandler.
+ */
+
+namespace DrupalProject\composer;
+
+use Composer\Script\Event;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class ScriptHandler
+{
+
+  protected static function getDrupalRoot($project_root)
+  {
+    return $project_root .  '/web';
+  }
+
+  public static function createRequiredFiles(Event $event)
+  {
+    $fs = new Filesystem();
+    $root = static::getDrupalRoot(getcwd());
+
+    $dirs = [
+      'modules',
+      'profiles',
+      'themes',
+    ];
+
+    // Required for unit testing
+    foreach ($dirs as $dir) {
+      if (!$fs->exists($root . '/'. $dir)) {
+        $fs->mkdir($root . '/'. $dir);
+        $fs->touch($root . '/'. $dir . '/.gitkeep');
+      }
+    }
+
+    // Create the files directory with chmod 0777
+    if (!$fs->exists($root . '/sites/default/files')) {
+      $oldmask = umask(0);
+      $fs->mkdir($root . '/sites/default/files', 0777);
+      umask($oldmask);
+      $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
+    }
+  }
+
+  // This is called by the QuickSilver deploy hook to convert from
+  // a 'lean' repository to a 'fat' repository. This should only be
+  // called when using this repository as a custom upstream, and
+  // updating it with `terminus composer <site>.<env> update`. This
+  // is not used in the GitHub PR workflow.
+  public static function prepareForPantheon()
+  {
+    // Get rid of any .git directories that Composer may have added.
+    // n.b. Ideally, there are none of these, as removing them may
+    // impair Composer's ability to update them later. However, leaving
+    // them in place prevents us from pushing to Pantheon.
+    $dirsToDelete = [];
+    $finder = new Finder();
+    foreach (
+      $finder
+        ->directories()
+        ->in(getcwd())
+        ->ignoreDotFiles(false)
+        ->ignoreVCS(false)
+        ->depth('> 0')
+        ->name('.git')
+      as $dir) {
+      $dirsToDelete[] = $dir;
+    }
+    $fs = new Filesystem();
+    $fs->remove($dirsToDelete);
+
+    // Fix up .gitignore: remove everything above the "::: cut :::" line
+    $gitignoreFile = getcwd() . '/.gitignore';
+    $gitignoreContents = file_get_contents($gitignoreFile);
+    $gitignoreContents = preg_replace('/.*::: cut :::*/s', '', $gitignoreContents);
+    file_put_contents($gitignoreFile, $gitignoreContents);
+  }
+}

--- a/scripts/github/add-commit-comment
+++ b/scripts/github/add-commit-comment
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+project="$1"
+sha="$2"
+comment="$3"
+site_url="$4"
+
+token="$(composer config --global github-oauth.github.com)"
+
+# Exit immediately on errors
+set -e
+
+if [ -n "$site_url" ] ; then
+  visit_site="[![Visit Site](https://raw.githubusercontent.com/pantheon-systems/ci-drops-8/0.1.0/data/img/visit-site-36.png)]($site_url)"
+fi
+
+if [ -n "$token" ] ; then
+  curl -d '{ "body": "'"$comment\\n\\n$visit_site"'" }' -X POST https://api.github.com/repos/$project/commits/$sha/comments?access_token=$token
+
+  echo $comment
+  echo
+  echo $visit_site
+fi

--- a/scripts/gitlab/add-commit-comment
+++ b/scripts/gitlab/add-commit-comment
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Exit immediately on errors
+set -e
+
+SITE_ID=$(terminus site:info $TERMINUS_SITE --field=id)
+DASHBOARD="https://dashboard.pantheon.io/sites/$SITE_ID#$TERMINUS_ENV"
+comment="Created multidev environment [$TERMINUS_SITE#$TERMINUS_ENV]($DASHBOARD)."
+visit_site="[![Visit Site](https://raw.githubusercontent.com/pantheon-systems/ci-drops-8/0.1.0/data/img/visit-site-36.png)](https://$TERMINUS_ENV-$TERMINUS_SITE.pantheonsite.io/)"
+
+if [ -n "$GITLAB_TOKEN" ] ; then
+  curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --form "note=$comment\\n\\n$visit_site" -X POST https://gitlab.com/api/v3/projects/$CI_PROJECT_ID/repository/commits/$CI_BUILD_REF/comments
+fi
+
+echo $comment
+echo
+echo $visit_site

--- a/tests/behat-pantheon.yml
+++ b/tests/behat-pantheon.yml
@@ -1,0 +1,21 @@
+#
+# behat.yml file for testing on Pantheon.
+#
+default:
+  suites:
+    default:
+      paths:
+        - %paths.base%/features
+        - %paths.base%/site-features
+      contexts:
+        - FeatureContext
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MinkContext
+  extensions:
+    Behat\MinkExtension:
+      goutte: ~
+      selenium2: ~
+      files_path: './data-files'
+    Drupal\DrupalExtension:
+      blackbox: ~
+      api_driver: 'drush'

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -19,3 +19,8 @@ default:
     Drupal\DrupalExtension:
       blackbox: ~
       api_driver: 'drush'
+local:
+  extensions:
+    Drupal\DrupalExtension:
+      drush:
+        root: '../'

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -1,0 +1,250 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Drupal\DrupalExtension\Context\MinkContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Behat\Hook\Scope\AfterStepScope;
+
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Define application features from the specific context.
+ */
+class FeatureContext extends RawDrupalContext implements Context, SnippetAcceptingContext {
+  /**
+   * Initializes context.
+   * Every scenario gets its own context object.
+   *
+   * @param array $parameters
+   *   Context parameters (set them in behat.yml)
+   */
+  public function __construct(array $parameters = []) {
+    // Initialize your context here
+  }
+
+  /** @var \Drupal\DrupalExtension\Context\MinkContext */
+  private $minkContext;
+  /** @BeforeScenario */
+  public function gatherContexts(BeforeScenarioScope $scope)
+  {
+      $environment = $scope->getEnvironment();
+      $this->minkContext = $environment->getContext('Drupal\DrupalExtension\Context\MinkContext');
+  }
+
+//
+// Place your definition and hook methods here:
+//
+//  /**
+//   * @Given I have done something with :stuff
+//   */
+//  public function iHaveDoneSomethingWith($stuff) {
+//    doSomethingWith($stuff);
+//  }
+//
+
+    /**
+     * Fills in form field with specified id|name|label|value
+     * Example: And I enter the value of the env var "TEST_PASSWORD" for "edit-account-pass-pass1"
+     *
+     * @Given I enter the value of the env var :arg1 for :arg2
+     */
+    public function fillFieldWithEnv($value, $field)
+    {
+        $this->minkContext->fillField($field, getenv($value));
+    }
+
+    /**
+     * @Given I wait for the progress bar to finish
+     */
+    public function iWaitForTheProgressBarToFinish() {
+      $this->iFollowMetaRefresh();
+    }
+
+    /**
+     * @Given I follow meta refresh
+     *
+     * https://www.drupal.org/node/2011390
+     */
+    public function iFollowMetaRefresh() {
+      while ($refresh = $this->getSession()->getPage()->find('css', 'meta[http-equiv="Refresh"]')) {
+        $content = $refresh->getAttribute('content');
+        $url = str_replace('0; URL=', '', $content);
+        $this->getSession()->visit($url);
+      }
+    }
+
+    /**
+     * @Given I have wiped the site
+     */
+    public function iHaveWipedTheSite()
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        passthru("terminus env:wipe $site.$env --yes");
+    }
+
+    /**
+     * @Given I have reinstalled
+     */
+    public function iHaveReinstalled()
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+        $site_name = getenv('TEST_SITE_NAME');
+        $site_mail = getenv('ADMIN_EMAIL');
+        $admin_password = getenv('ADMIN_PASSWORD');
+
+        passthru("terminus --yes drush $site.$env -- --yes site-install standard --site-name=\"$site_name\" --site-mail=\"$site_mail\" --account-name=admin --account-pass=\"$admin_password\"'");
+    }
+
+    /**
+     * @Given I have run the drush command :arg1
+     */
+    public function iHaveRunTheDrushCommand($arg1)
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        $return = '';
+        $output = array();
+        exec("terminus drush $site.$env -- " . $arg1, $output, $return);
+        // echo $return;
+        // print_r($output);
+
+    }
+
+    /**
+     * @Given I have committed my changes with comment :arg1
+     */
+    public function iHaveCommittedMyChangesWithComment($arg1)
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        passthru("terminus --yes $site.$env env:commit --message='$arg1'");
+    }
+
+    /**
+     * @Given I have exported configuration
+     */
+    public function iHaveExportedConfiguration()
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        $return = '';
+        $output = array();
+        exec("terminus drush $site.$env -- config-export -y", $output, $return);
+    }
+
+    /**
+     * @Given I wait :seconds seconds
+     */
+    public function iWaitSeconds($seconds)
+    {
+        sleep($seconds);
+    }
+
+    /**
+     * @Given I wait :seconds seconds or until I see :text
+     */
+    public function iWaitSecondsOrUntilISee($seconds, $text)
+    {
+        $errorNode = $this->spin( function($context) use($text) {
+            $node = $context->getSession()->getPage()->find('named', array('content', $text));
+            if (!$node) {
+              return false;
+            }
+            return $node->isVisible();
+        }, $seconds);
+
+        // Throw to signal a problem if we were passed back an error message.
+        if (is_object($errorNode)) {
+          throw new Exception("Error detected when waiting for '$text': " . $errorNode->getText());
+        }
+    }
+
+    // http://docs.behat.org/en/v2.5/cookbook/using_spin_functions.html
+    // http://mink.behat.org/en/latest/guides/traversing-pages.html#selectors
+    public function spin ($lambda, $wait = 60)
+    {
+        for ($i = 0; $i <= $wait; $i++)
+        {
+            if ($i > 0) {
+              sleep(1);
+            }
+
+            $debugContent = $this->getSession()->getPage()->getContent();
+            file_put_contents("/tmp/mink/debug-" . $i, "\n\n\n=================================\n$debugContent\n=================================\n\n\n");
+
+            try {
+                if ($lambda($this)) {
+                    return true;
+                }
+            } catch (Exception $e) {
+                // do nothing
+            }
+
+            // If we do not see the text we are waiting for, fail fast if
+            // we see a Drupal 8 error message pane on the page.
+            $node = $this->getSession()->getPage()->find('named', array('content', 'Error'));
+            if ($node) {
+              $errorNode = $this->getSession()->getPage()->find('css', '.messages--error');
+              if ($errorNode) {
+                return $errorNode;
+              }
+              $errorNode = $this->getSession()->getPage()->find('css', 'main');
+              if ($errorNode) {
+                return $errorNode;
+              }
+              return $node;
+            }
+        }
+
+        $backtrace = debug_backtrace();
+
+        throw new Exception(
+            "Timeout thrown by " . $backtrace[1]['class'] . "::" . $backtrace[1]['function'] . "()\n" .
+            $backtrace[1]['file'] . ", line " . $backtrace[1]['line']
+        );
+
+        return false;
+    }
+
+    /**
+     * @AfterStep
+     */
+    public function afterStep(AfterStepScope $scope)
+    {
+        // Do nothing on steps that pass
+        $result = $scope->getTestResult();
+        if ($result->isPassed()) {
+            return;
+        }
+
+        // Otherwise, dump the page contents.
+        $session = $this->getSession();
+        $page = $session->getPage();
+        $html = $page->getContent();
+        $html = static::trimHead($html);
+
+        print "::::::::::::::::::::::::::::::::::::::::::::::::\n";
+        print $html . "\n";
+        print "::::::::::::::::::::::::::::::::::::::::::::::::\n";
+    }
+
+    /**
+     * Remove everything in the '<head>' element except the
+     * title, because it is long and uninteresting.
+     */
+    protected static function trimHead($html)
+    {
+        $html = preg_replace('#\<head\>.*\<title\>#sU', '<head><title>', $html);
+        $html = preg_replace('#\</title\>.*\</head\>#sU', '</title></head>', $html);
+        return $html;
+    }
+}

--- a/tests/features/content.feature
+++ b/tests/features/content.feature
@@ -1,0 +1,30 @@
+Feature: Content
+  In order to test some basic Behat functionality
+  As a website user
+  I need to be able to see that the Drupal and Drush drivers are working
+
+# TODO:
+# Add tests for:
+#   - Creating district
+#   - Creating district landing page
+#   - Creating district voting page
+#   - Creating district ballot
+#
+# Use examples from # https://github.com/pantheon-systems/example-drops-8-composer/blob/master/tests/features/content.feature
+
+  @api
+  Scenario: Create users
+    Given users:
+    | name     | mail            | status |
+    | Joe User | joe@example.com | 1      |
+    And I am logged in as a user with the "administrator" role
+    When I visit "admin/people"
+    Then I should see the link "Joe User"
+
+  @api
+  Scenario: Login as a user created during this scenario
+    Given users:
+    | name      | status | mail             |
+    | Test user |      1 | test@example.com |
+    When I am logged in as "Test user"
+    Then I should see the link "Log out"

--- a/tests/features/content.feature
+++ b/tests/features/content.feature
@@ -10,7 +10,7 @@ Feature: Content
 #   - Creating district voting page
 #   - Creating district ballot
 #
-# Use examples from # https://github.com/pantheon-systems/example-drops-8-composer/blob/master/tests/features/content.feature
+# Used examples from https://github.com/pantheon-systems/example-drops-8-composer/blob/master/tests/features/content.feature
 
   @api
   Scenario: Create users
@@ -27,4 +27,5 @@ Feature: Content
     | name      | status | mail             |
     | Test user |      1 | test@example.com |
     When I am logged in as "Test user"
-    Then I should see the link "Log out"
+    When I visit "/admin"
+    Then I should see the text "Administration"

--- a/tests/features/content.feature
+++ b/tests/features/content.feature
@@ -9,6 +9,7 @@ Feature: Content
 #   - Creating district landing page
 #   - Creating district voting page
 #   - Creating district ballot
+#   - Creating district aid users
 #
 # Used examples from https://github.com/pantheon-systems/example-drops-8-composer/blob/master/tests/features/content.feature
 
@@ -20,12 +21,3 @@ Feature: Content
     And I am logged in as a user with the "administrator" role
     When I visit "admin/people"
     Then I should see the link "Joe User"
-
-  @api
-  Scenario: Login as a user created during this scenario
-    Given users:
-    | name      | status | mail             |
-    | Test user |      1 | test@example.com |
-    When I am logged in as "Test user"
-    When I visit "/admin"
-    Then I should see the text "Administration"

--- a/tests/scripts/run-behat
+++ b/tests/scripts/run-behat
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Go to base level of project
+cd "$(dirname $0)/../../"
+
+if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]
+then
+  echo 'No test site specified. Set TERMINUS_SITE and TERMINUS_ENV.'
+  exit 1
+fi
+
+echo "::::::::::::::::::::::::::::::::::::::::::::::::"
+echo "Behat test site: $TERMINUS_SITE.$TERMINUS_ENV"
+echo "::::::::::::::::::::::::::::::::::::::::::::::::"
+echo
+
+# Exit immediately on errors, and echo commands as they are executed.
+set -ex
+
+# Set the $PATH to include the global composer bin directory.
+PATH=$PATH:~/.composer/vendor/bin
+
+# Create a drush alias file so that Behat tests can be executed against Pantheon.
+terminus aliases
+# Drush Behat driver fails without this option.
+echo "\$options['strict'] = 0;" >> ~/.drush/pantheon.aliases.drushrc.php
+
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "https://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "alias":  "@pantheon.'$TERMINUS_SITE'.'$TERMINUS_ENV'" }}}}'
+cd tests && ../vendor/bin/behat --config=behat-pantheon.yml "$@"

--- a/tests/scripts/run-behat
+++ b/tests/scripts/run-behat
@@ -3,27 +3,10 @@
 # Go to base level of project
 cd "$(dirname $0)/../../"
 
-if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]
-then
-  echo 'No test site specified. Set TERMINUS_SITE and TERMINUS_ENV.'
-  exit 1
-fi
-
-echo "::::::::::::::::::::::::::::::::::::::::::::::::"
-echo "Behat test site: $TERMINUS_SITE.$TERMINUS_ENV"
-echo "::::::::::::::::::::::::::::::::::::::::::::::::"
-echo
-
 # Exit immediately on errors, and echo commands as they are executed.
 set -ex
 
 # Set the $PATH to include the global composer bin directory.
 PATH=$PATH:~/.composer/vendor/bin
 
-# Create a drush alias file so that Behat tests can be executed against Pantheon.
-terminus aliases
-# Drush Behat driver fails without this option.
-echo "\$options['strict'] = 0;" >> ~/.drush/pantheon.aliases.drushrc.php
-
-export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "https://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "alias":  "@pantheon.'$TERMINUS_SITE'.'$TERMINUS_ENV'" }}}}'
-cd tests && ../vendor/bin/behat --config=behat-pantheon.yml "$@"
+cd tests && ../vendor/bin/behat --config=behat.yml --profile local "$@"

--- a/tests/scripts/run-pantheon-behat
+++ b/tests/scripts/run-pantheon-behat
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Go to base level of project
+cd "$(dirname $0)/../../"
+
+if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]
+then
+  echo 'No test site specified. Set TERMINUS_SITE and TERMINUS_ENV.'
+  exit 1
+fi
+
+echo "::::::::::::::::::::::::::::::::::::::::::::::::"
+echo "Behat test site: $TERMINUS_SITE.$TERMINUS_ENV"
+echo "::::::::::::::::::::::::::::::::::::::::::::::::"
+echo
+
+# Exit immediately on errors, and echo commands as they are executed.
+set -ex
+
+# Set the $PATH to include the global composer bin directory.
+PATH=$PATH:~/.composer/vendor/bin
+
+# Create a drush alias file so that Behat tests can be executed against Pantheon.
+terminus aliases
+# Drush Behat driver fails without this option.
+echo "\$options['strict'] = 0;" >> ~/.drush/pantheon.aliases.drushrc.php
+
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "https://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "alias":  "@pantheon.'$TERMINUS_SITE'.'$TERMINUS_ENV'" }}}}'
+cd tests && ../vendor/bin/behat --config=behat.yml "$@"


### PR DESCRIPTION
Wire up CircleCI to build and test following the examples from:

* https://github.com/pantheon-systems/example-drops-8-composer
* https://github.com/pantheon-systems/terminus-build-tools-plugin

This will allow us to not have to push to Pantheon directly, but rather push to Github and rely on CircleCI to run `composer` and push resulting assets to Pantheon.

High level steps:
* Run CircleCI job to build and deploy each push to Pantheon multidev environment (in parallel a job is also ran to do basic linting and unit tests (none currently))
* Run behat tests against remote environment
* If master, merge multidev into `dev` environment

CircleCI builds: https://circleci.com/gh/SFDigitalServices/participatory_budget

Remaining TODOs:
- [ ] Move code into `web/` folder to match example project setup
- [ ] Delete vendored code from this repository since CircleCI will now build and push this to Pantheon

Some questions to consider:
* Do you think this approach is appropriate for all Pantheon projects?
* Would you know how this works if you picked up this project? Does it need more detail anywhere?
* What do think of this testing and deployment process?